### PR TITLE
Add _jupyter_server_extension_paths.

### DIFF
--- a/papermillhub/nbext.py
+++ b/papermillhub/nbext.py
@@ -237,6 +237,12 @@ class PapermillhubHandler(APIHandler):
         self.set_status(204)
 
 
+def _jupyter_server_extension_paths():
+    return [{
+        "module": "papermillhub.nbext"
+    }]
+
+
 def load_jupyter_server_extension(nb_server_app):
     """Setup the papermillhub server extension."""
     web_app = nb_server_app.web_app


### PR DESCRIPTION
This is apparently required. It is [mentioned in the docs](https://jupyter-notebook.readthedocs.io/en/stable/examples/Notebook/Distributing%20Jupyter%20Extensions%20as%20Python%20Packages.html#Defining-the-server-extension-and-nbextension)
though it is not included in the list of required API.

Before:

```
$ jupyter serverextension enable --py papermillhub.nbext --sys-prefix
Traceback (most recent call last):
  File "/home/dallan/miniconda3/envs/py38/bin/jupyter-serverextension", line 8, in <module>
    sys.exit(main())
  File "/home/dallan/miniconda3/envs/py38/lib/python3.8/site-packages/jupyter_core/application.py", line 270, in launch_instance
    return super(JupyterApp, cls).launch_instance(argv=argv, **kwargs)
  File "/home/dallan/miniconda3/envs/py38/lib/python3.8/site-packages/traitlets/config/application.py", line 837, in launch_instance
    app.start()
  File "/home/dallan/miniconda3/envs/py38/lib/python3.8/site-packages/notebook/serverextensions.py", line 294, in start
    super(ServerExtensionApp, self).start()
  File "/home/dallan/miniconda3/envs/py38/lib/python3.8/site-packages/jupyter_core/application.py", line 259, in start
    self.subapp.start()
  File "/home/dallan/miniconda3/envs/py38/lib/python3.8/site-packages/notebook/serverextensions.py", line 211, in start
    self.toggle_server_extension_python(arg)
  File "/home/dallan/miniconda3/envs/py38/lib/python3.8/site-packages/notebook/serverextensions.py", line 200, in toggle_server_extension_python
    m, server_exts = _get_server_extension_metadata(package)
  File "/home/dallan/miniconda3/envs/py38/lib/python3.8/site-packages/notebook/serverextensions.py", line 330, in _get_server_extension_metadata
    raise KeyError(u'The Python module {} does not include any valid server extensions'.format(module))
KeyError: 'The Python module papermillhub.nbext does not include any valid server extensions'
```

After:

```
$ jupyter serverextension enable --py papermillhub.nbext --sys-prefix
Enabling: papermillhub.nbext
- Writing config: /home/dallan/miniconda3/envs/py38/etc/jupyter
    - Validating...
      papermillhub.nbext  OK
```